### PR TITLE
Auto-contribute improvements & publisher exclusion

### DIFF
--- a/BraveRewards.xcodeproj/project.pbxproj
+++ b/BraveRewards.xcodeproj/project.pbxproj
@@ -28,6 +28,7 @@
 		0A9060222285E0BE00F58252 /* DateExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A9060212285E0BE00F58252 /* DateExtensions.swift */; };
 		0A9060292285E4C100F58252 /* DateExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A9060232285E19E00F58252 /* DateExtensionsTests.swift */; };
 		0A91598B22B92A4900CCC119 /* FaviconData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A91598A22B92A4900CCC119 /* FaviconData.swift */; };
+		0AE5C08E22CA26B300DFF3EE /* PublisherIconCircleImageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0AE5C08D22CA26B300DFF3EE /* PublisherIconCircleImageView.swift */; };
 		2704834B2220E9380051239C /* UIImageExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2704834A2220E9380051239C /* UIImageExtensions.swift */; };
 		2704834D2220EC1D0051239C /* BundleExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2704834C2220EC1D0051239C /* BundleExtensions.swift */; };
 		2704834F2220EFA50051239C /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 2704834E2220EC720051239C /* Images.xcassets */; };
@@ -207,6 +208,7 @@
 		0A9060212285E0BE00F58252 /* DateExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DateExtensions.swift; sourceTree = "<group>"; };
 		0A9060232285E19E00F58252 /* DateExtensionsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DateExtensionsTests.swift; sourceTree = "<group>"; };
 		0A91598A22B92A4900CCC119 /* FaviconData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FaviconData.swift; sourceTree = "<group>"; };
+		0AE5C08D22CA26B300DFF3EE /* PublisherIconCircleImageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PublisherIconCircleImageView.swift; sourceTree = "<group>"; };
 		2704834A2220E9380051239C /* UIImageExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIImageExtensions.swift; sourceTree = "<group>"; };
 		2704834C2220EC1D0051239C /* BundleExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BundleExtensions.swift; sourceTree = "<group>"; };
 		2704834E2220EC720051239C /* Images.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Images.xcassets; sourceTree = "<group>"; };
@@ -538,6 +540,7 @@
 				27371B7F22A7111200E13C00 /* DetailActionableRow.swift */,
 				0A91598A22B92A4900CCC119 /* FaviconData.swift */,
 				5E2A934A22C15F05002EDFFD /* LinkLabel.swift */,
+				0AE5C08D22CA26B300DFF3EE /* PublisherIconCircleImageView.swift */,
 			);
 			path = Common;
 			sourceTree = "<group>";
@@ -1057,6 +1060,7 @@
 				2730DF8D2231C75B0031845C /* SettingsRewardsSectionView.swift in Sources */,
 				2726B58222527BC300B9EAF7 /* WalletActivityView.swift in Sources */,
 				27371B8122A7118500E13C00 /* ArrayExtensions.swift in Sources */,
+				0AE5C08E22CA26B300DFF3EE /* PublisherIconCircleImageView.swift in Sources */,
 				273404742220BA73008CABC9 /* GradientView.swift in Sources */,
 				27F4CACF2294715100935B45 /* AdsDetailsViewController.swift in Sources */,
 				278A6B46225C08AE00175678 /* WalletDetailsViewController.swift in Sources */,

--- a/BraveRewardsUI/Common/PublisherIconCircleImageView.swift
+++ b/BraveRewardsUI/Common/PublisherIconCircleImageView.swift
@@ -1,0 +1,32 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import UIKit
+
+class PublisherIconCircleImageView: UIImageView {
+  
+  init(size: CGFloat) {
+    super.init(frame: .zero)
+    
+    snp.makeConstraints {
+      $0.size.equalTo(size)
+    }
+    
+    setContentHuggingPriority(.required, for: .horizontal)
+    
+    contentMode = .scaleAspectFill
+    clipsToBounds = true
+    image = UIImage(frameworkResourceNamed: "defaultFavicon")
+    
+    layer.do {
+      $0.cornerRadius = size / 2.0
+      $0.borderColor = Colors.neutral800.cgColor
+      $0.borderWidth = 1.0 / UIScreen.main.scale
+    }
+  }
+  
+  @available(*, unavailable)
+  required init?(coder aDecoder: NSCoder) { fatalError() }
+  
+}

--- a/BraveRewardsUI/Common/SwitchRow.swift
+++ b/BraveRewardsUI/Common/SwitchRow.swift
@@ -6,6 +6,8 @@ import UIKit
 
 class SwitchRow: UIStackView {
   
+  var valueChanged: ((Bool) -> Void)?
+  
   private struct UX {
     static let textColor = Colors.grey200
   }
@@ -26,6 +28,12 @@ class SwitchRow: UIStackView {
    
     addArrangedSubview(textLabel)
     addArrangedSubview(toggleSwitch)
+    
+    toggleSwitch.addTarget(self, action: #selector(switchToggled(sender:)), for: .valueChanged)
+  }
+  
+  @objc func switchToggled(sender: UISwitch) {
+    valueChanged?(sender.isOn)
   }
   
   @available(*, unavailable)

--- a/BraveRewardsUI/Publisher/PublisherSummaryView.swift
+++ b/BraveRewardsUI/Publisher/PublisherSummaryView.swift
@@ -6,6 +6,12 @@ import UIKit
 
 class PublisherSummaryView: UIView {
   
+  var autoContributeChanged: ((Bool) -> Void)?
+  
+  func setAutoContribute(enabled: Bool) {
+    autoContributeRow.toggleSwitch.isOn = enabled
+  }
+  
   lazy var monthlyTipView = DetailActionableRow().then {
     $0.textLabel.text = Strings.TipSiteMonthly
   }
@@ -28,6 +34,7 @@ class PublisherSummaryView: UIView {
   let attentionView = PublisherAttentionView()
   private let autoContributeRow = SwitchRow().then {
     $0.textLabel.text = Strings.AutoContributeSwitchLabel
+    $0.toggleSwitch.isOn = true
   }
   let tipButton = ActionButton(type: .system).then {
     $0.tintColor = Colors.blurple400
@@ -59,6 +66,10 @@ class PublisherSummaryView: UIView {
     stackView.setCustomSpacing(20.0, after: stackView.arrangedSubviews.last!)
     stackView.addArrangedSubview(tipButton)
     
+    autoContributeRow.valueChanged = { enabled in
+      self.autoContributeChanged?(enabled)
+    }
+    
     scrollView.snp.makeConstraints {
       $0.edges.equalTo(self)
     }
@@ -75,8 +86,8 @@ class PublisherSummaryView: UIView {
     }
   }
   
-  func updateViewVisibility(autoContributionEnabled: Bool) {
-    autoContributeStackView.isHidden = !autoContributionEnabled
+  func updateViewVisibility(globalAutoContributionEnabled: Bool) {
+    autoContributeStackView.isHidden = !globalAutoContributionEnabled
   }
 }
 

--- a/BraveRewardsUI/Publisher/PublisherView.swift
+++ b/BraveRewardsUI/Publisher/PublisherView.swift
@@ -22,18 +22,8 @@ class PublisherView: UIStackView {
     }
   }
   
-  let faviconImageView = UIImageView().then {
-    $0.backgroundColor = UX.faviconBackgroundColor
-    $0.contentMode = .scaleAspectFill
-    $0.clipsToBounds = true
-    $0.layer.cornerRadius = UX.faviconSize.width / 2.0
-    $0.layer.borderColor = UX.faviconBorderColor.cgColor
-    $0.layer.borderWidth = 1.0 / UIScreen.main.scale
-    $0.setContentHuggingPriority(.required, for: .horizontal)
-    $0.image = UIImage(frameworkResourceNamed: "defaultFavicon")
-  }
+  let faviconImageView = PublisherIconCircleImageView(size: UX.faviconSize)
   
-  // "reddit.com" / "Bart Baker on YouTube"
   let publisherNameLabel = UILabel().then {
     $0.textColor = UX.publisherNameColor
     $0.font = .systemFont(ofSize: 18.0, weight: .medium)
@@ -55,9 +45,7 @@ class PublisherView: UIStackView {
   // MARK: -
   
   private struct UX {
-    static let faviconBackgroundColor = Colors.neutral800
-    static let faviconSize = CGSize(width: 48.0, height: 48.0)
-    static let faviconBorderColor = Colors.neutral800
+    static let faviconSize: CGFloat = 48
     static let publisherNameColor = Colors.grey000
     static let verifiedStatusColor = Colors.grey200
   }

--- a/BraveRewardsUI/Settings/Auto-Contribute/Details/AutoContributeCell.swift
+++ b/BraveRewardsUI/Settings/Auto-Contribute/Details/AutoContributeCell.swift
@@ -19,13 +19,8 @@ class AutoContributeCell: UITableViewCell, TableViewReusable {
     $0.backgroundColor = Colors.blurple800
   }
   
-  let siteImageView = UIImageView().then {
-    $0.setContentHuggingPriority(.required, for: .horizontal)
-    $0.contentMode = .scaleAspectFit
-    $0.snp.makeConstraints {
-      $0.width.equalTo(28.0)
-    }
-  }
+  let siteImageView = PublisherIconCircleImageView(size: 28)
+  
   let verifiedStatusImageView = UIImageView(image: UIImage(frameworkResourceNamed: "icn-verify")).then {
     $0.isHidden = true
   }
@@ -59,8 +54,8 @@ class AutoContributeCell: UITableViewCell, TableViewReusable {
       $0.trailing.lessThanOrEqualTo(attentionLabel.snp.leading).offset(-10.0)
     }
     verifiedStatusImageView.snp.makeConstraints {
-      $0.top.equalTo(siteStackView)
-      $0.leading.equalTo(siteImageView.snp.trailing).offset(-4.0)
+      $0.top.equalTo(siteStackView).offset(-4.0)
+      $0.leading.equalTo(siteImageView.snp.trailing).offset(-8.0)
     }
     attentionLabel.snp.makeConstraints {
       $0.trailing.equalTo(contentView).inset(15.0)

--- a/BraveRewardsUI/Settings/Auto-Contribute/Details/AutoContributeDetailsViewController.swift
+++ b/BraveRewardsUI/Settings/Auto-Contribute/Details/AutoContributeDetailsViewController.swift
@@ -317,7 +317,14 @@ extension AutoContributeDetailViewController: UITableViewDataSource, UITableView
       }
       let cell = tableView.dequeueReusableCell(for: indexPath) as AutoContributeCell
       cell.selectionStyle = .none
-      cell.siteImageView.image = UIImage(frameworkResourceNamed: "defaultFavicon")
+      
+      if let url = state.faviconURL {
+        state.dataSource?.retrieveFavicon(with: url) { data in
+          cell.siteImageView.image = data?.image
+          cell.siteImageView.backgroundColor = data?.backgroundColor
+        }
+      }
+      
       cell.verifiedStatusImageView.isHidden = !publisher.verified
       let provider = " \(publisher.provider.isEmpty ? "" : String(format: Strings.OnProviderText, publisher.provider))"
       let attrName = NSMutableAttributedString(string: publisher.name).then {


### PR DESCRIPTION
Ref #47 

- Autocontribute setting per publisher is implemented, toggle the switch to include or exclude publisher from AC, this changes are reflected on AC settings screen as well.

- Auto contribute settings how show a favicons in the same way as on publishers summary panel

<img width="544" alt="Zrzut ekranu 2019-07-1 o 19 13 23" src="https://user-images.githubusercontent.com/6950387/60592972-0bd0b200-9da2-11e9-95dc-61bde9563c8d.png">
