### PR TITLE
For AC list fetch favicons based on publisher url.

### DIFF
--- a/BraveRewardsUI/Settings/Auto-Contribute/Details/AutoContributeDetailsViewController.swift
+++ b/BraveRewardsUI/Settings/Auto-Contribute/Details/AutoContributeDetailsViewController.swift
@@ -318,7 +318,7 @@ extension AutoContributeDetailViewController: UITableViewDataSource, UITableView
       let cell = tableView.dequeueReusableCell(for: indexPath) as AutoContributeCell
       cell.selectionStyle = .none
       
-      if let url = state.faviconURL {
+      if let url = URL(string: publisher.url) {
         state.dataSource?.retrieveFavicon(with: url) { data in
           cell.siteImageView.image = data?.image
           cell.siteImageView.backgroundColor = data?.backgroundColor


### PR DESCRIPTION
Previously all items in the list were set to currently opened tab icon :(