### PR TITLE
Added unclaimedFundsURL for when the user taps learnMore on the rewar…

### DIFF
--- a/BraveRewardsUI/Common/LinkLabel.swift
+++ b/BraveRewardsUI/Common/LinkLabel.swift
@@ -190,4 +190,5 @@ extension LinkLabel: UITextViewDelegate {
 struct DisclaimerLinks {
   static let termsOfUseURL = "https://brave.com/terms-of-use/"
   static let policyURL = "https://brave.com/privacy/#rewards"
+  static let unclaimedFundsURL = "https://brave.com/faq-rewards/#unclaimed-funds"
 }

--- a/BraveRewardsUI/Publisher/PublisherView.swift
+++ b/BraveRewardsUI/Publisher/PublisherView.swift
@@ -22,12 +22,34 @@ class PublisherView: UIStackView {
     }
   }
   
+  func updatePublisherName(_ name: String, provider: String) {
+    publisherNameLabel.attributedText = {
+      let paragraphStyle = NSMutableParagraphStyle()
+      paragraphStyle.lineBreakMode = .byWordWrapping
+      
+      let text = NSMutableAttributedString(string: name.trimmingCharacters(in: .whitespacesAndNewlines), attributes: [
+        .font: UIFont.systemFont(ofSize: 18.0, weight: .medium),
+        .foregroundColor: UX.publisherNameColor
+      ])
+      
+      if !provider.isEmpty {
+        text.append(NSMutableAttributedString(string: provider.trimmingCharacters(in: .whitespacesAndNewlines), attributes: [
+          .font: UIFont.systemFont(ofSize: 18.0),
+          .foregroundColor: UX.publisherNameColor
+        ]))
+      }
+      
+      text.addAttribute(.paragraphStyle, value: paragraphStyle, range: NSRange(location: 0, length: text.length))
+      return text
+    }()
+  }
+  
   let faviconImageView = PublisherIconCircleImageView(size: UX.faviconSize)
   
-  let publisherNameLabel = UILabel().then {
+  private let publisherNameLabel = UILabel().then {
     $0.textColor = UX.publisherNameColor
     $0.font = .systemFont(ofSize: 18.0, weight: .medium)
-    $0.numberOfLines = 0
+    $0.numberOfLines = 2
   }
   
   /// The learn more button on the unverified publisher disclaimer was tapped

--- a/BraveRewardsUI/Tipping/TippingView.swift
+++ b/BraveRewardsUI/Tipping/TippingView.swift
@@ -16,6 +16,7 @@ extension TippingViewController {
       let isMonthly = optionSelectionView.isMonthly
       
       confirmationView.faviconImageView.image = overviewView.faviconImageView.image
+      confirmationView.faviconImageView.backgroundColor = overviewView.faviconImageView.backgroundColor
       confirmationView.subtitleLabel.text = isMonthly ? Strings.TippingMonthlyTitle : Strings.TippingOneTimeTitle
       
       confirmationView.infoLabel.text = "\(name)\n\(tipAmount) BAT\(isMonthly ? ", \(Strings.TippingRecurring)" : "")"

--- a/BraveRewardsUI/Tipping/TippingViewController.swift
+++ b/BraveRewardsUI/Tipping/TippingViewController.swift
@@ -78,11 +78,8 @@ class TippingViewController: UIViewController, UIViewControllerTransitioningDele
       self?.state.delegate?.loadNewTabWithURL(url)
     }
     
-    // FIXME: Set this disclaimer hidden based on whether or not the publisher is verified
-    tippingView.overviewView.disclaimerView.isHidden = true
-    
+    tippingView.overviewView.disclaimerView.isHidden = !publisherInfo.verified
     tippingView.optionSelectionView.setWalletBalance(state.ledger.balanceString, crypto: "BAT")
-    // FIXME: Remove fake data
     tippingView.optionSelectionView.options = TippingViewController.defaultTippingAmounts.map {
       TippingOption.batAmount(BATValue($0), dollarValue: state.ledger.dollarStringForBATAmount($0) ?? "")
     }
@@ -104,7 +101,9 @@ class TippingViewController: UIViewController, UIViewControllerTransitioningDele
       
       if let dataSource = self.state.dataSource, let favIconURL = self.state.faviconURL {
         dataSource.retrieveFavicon(with: favIconURL, completion: { favIconData in
-          self.tippingView.overviewView.faviconImageView.image = favIconData?.image
+          guard let favIconData = favIconData else { return }
+          self.tippingView.overviewView.faviconImageView.image = favIconData.image
+          self.tippingView.overviewView.faviconImageView.backgroundColor = favIconData.backgroundColor
         })
       }
       

--- a/BraveRewardsUI/Wallet/WalletViewController.swift
+++ b/BraveRewardsUI/Wallet/WalletViewController.swift
@@ -204,10 +204,11 @@ class WalletViewController: UIViewController, RewardsSummaryProtocol {
       }
       
       self.state.ledger.listRecurringTips { [weak self] in
-        guard let self = self else { return }
-        guard let recurringTip = $0.filter({ $0.id == host && $0.rewardsCategory == .recurringTip }).first else { return }
+        guard let self = self, let recurringTip = $0.first(where: { $0.id == host && $0.rewardsCategory == .recurringTip }) else { return }
         
-        self.publisherSummaryView.monthlyTipView.batValueView.amountLabel.text = "\((recurringTip.contributions.first?.value ?? 0))"
+        guard let contributionAmount = recurringTip.contributions.first?.value else { return }
+        
+        self.publisherSummaryView.monthlyTipView.batValueView.amountLabel.text = "\(Int(contributionAmount))"
         self.publisherSummaryView.monthlyTipView.isHidden = false
       }
       


### PR DESCRIPTION
Fixes: https://github.com/brave/brave-rewards-ios/issues/42

- Added unclaimedFundsURL for when the user taps learnMore on the rewards panel. 
- Added the provider to the user's name when there is one. 
- Handle "learn more" options when the user chooses it.