### PR TITLE
Tipping selection, remove recurring tips

### DIFF
--- a/BraveRewards.xcodeproj/project.pbxproj
+++ b/BraveRewards.xcodeproj/project.pbxproj
@@ -148,6 +148,7 @@
 		27F4CAD12294773600935B45 /* LabelAccessoryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 27F4CAD02294773600935B45 /* LabelAccessoryView.swift */; };
 		59146FE322BC1A3B0085E420 /* DataLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59146FE222BC1A3B0085E420 /* DataLoader.swift */; };
 		59512897228CF3F8002D3791 /* Strings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59512896228CF3F8002D3791 /* Strings.swift */; };
+		5E1AB45E22D4EBA500CBE581 /* TippingSelectionViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E1AB45D22D4EBA500CBE581 /* TippingSelectionViewController.swift */; };
 		5E2A934B22C15F05002EDFFD /* LinkLabel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E2A934A22C15F05002EDFFD /* LinkLabel.swift */; };
 /* End PBXBuildFile section */
 
@@ -330,6 +331,7 @@
 		59146FE222BC1A3B0085E420 /* DataLoader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DataLoader.swift; sourceTree = "<group>"; };
 		5941A4E922A4A19F00F82330 /* ArrayExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArrayExtensions.swift; sourceTree = "<group>"; };
 		59512896228CF3F8002D3791 /* Strings.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Strings.swift; sourceTree = "<group>"; };
+		5E1AB45D22D4EBA500CBE581 /* TippingSelectionViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TippingSelectionViewController.swift; sourceTree = "<group>"; };
 		5E2A934A22C15F05002EDFFD /* LinkLabel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LinkLabel.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -595,6 +597,7 @@
 				272B7875222498EA00B7B81E /* TippingSelectionView.swift */,
 				2774BBBE2227587E00160619 /* InsufficientFundsButton.swift */,
 				27AFF5432229798F009320F5 /* TippingConfirmationView.swift */,
+				5E1AB45D22D4EBA500CBE581 /* TippingSelectionViewController.swift */,
 			);
 			path = Tipping;
 			sourceTree = "<group>";
@@ -1000,6 +1003,7 @@
 				274CDD2C225D446800FA7364 /* AutoContributeDetailsViewController.swift in Sources */,
 				2730DF8B2231A72F0031845C /* SettingsSectionView.swift in Sources */,
 				59512897228CF3F8002D3791 /* Strings.swift in Sources */,
+				5E1AB45E22D4EBA500CBE581 /* TippingSelectionViewController.swift in Sources */,
 				27F4C1D922569E2B00CFCD67 /* TipsDetailViewController.swift in Sources */,
 				27371B8022A7111300E13C00 /* DetailActionableRow.swift in Sources */,
 				27A4707D2242EA6C00596431 /* GrabberView.swift in Sources */,

--- a/BraveRewardsExample/ViewController.swift
+++ b/BraveRewardsExample/ViewController.swift
@@ -40,6 +40,13 @@ class UIMockLedger: BraveLedger {
     }
   }
   
+  override var balance: Balance? {
+    return Balance().then {
+      $0.total = 30.0
+      $0.rates = ["USD": 0.3]
+    }
+  }
+  
   override func balanceReport(for month: ActivityMonth, year: Int32) -> BalanceReportInfo {
     // Returns the same values for all months at the moment.
     // Could expand this to play with different values based on month or year.

--- a/BraveRewardsUI/Common/Button.swift
+++ b/BraveRewardsUI/Common/Button.swift
@@ -80,7 +80,6 @@ class Button: UIButton {
             loaderView.removeFromSuperview()
           }
         }
-        break
       }
     }
   }

--- a/BraveRewardsUI/Localized Strings/Strings.swift
+++ b/BraveRewardsUI/Localized Strings/Strings.swift
@@ -52,6 +52,7 @@ public extension Strings {
   static let SettingsAdsTitle = NSLocalizedString("BraveRewardsSettingsAdsTitle", bundle: Bundle.RewardsUI, value: "Ads", comment: "")
   static let NotificationRecurringTipTitle = NSLocalizedString("BraveRewardsNotificationRecurringTipTitle", bundle: Bundle.RewardsUI, value: "Recurring Tips", comment: "")
   static let EmptyWalletTitle = NSLocalizedString("BraveRewardsEmptyWalletTitle", bundle: Bundle.RewardsUI, value: "Sorry, no tokens yet.", comment: "")
+  static let RecurringTipTitle = NSLocalizedString("BraveRewardsRecurringTipTitle", bundle: Bundle.RewardsUI, value: "Recurring Tip", comment: "")
   static let UnverifiedPublisherDisclaimer = NSLocalizedString("BraveRewardsUnverifiedPublisherDisclaimer", bundle: Bundle.RewardsUI, value: "This creator has not yet signed up to receive contributions from Brave users. Any tips you send will remain in your wallet until they verify.", comment: "")
   static let SettingsGrantClaimButtonTitle = NSLocalizedString("BraveRewardsSettingsGrantClaimButtonTitle", bundle: Bundle.RewardsUI, value: "Claim", comment: "")
   static let AutoContributeMinimumLength = NSLocalizedString("BraveRewardsAutoContributeMinimumLength", bundle: Bundle.RewardsUI, value: "Minimum Length", comment: "")

--- a/BraveRewardsUI/Publisher/PublisherView.swift
+++ b/BraveRewardsUI/Publisher/PublisherView.swift
@@ -106,12 +106,15 @@ class PublisherView: UIStackView {
     $0.adjustsFontSizeToFitWidth = true
   }
   
-  let checkAgainButton = Button().then {
+  let checkAgainButton = Button(type: .system).then {
     $0.setTitleColor(Colors.blue500, for: .normal)
     $0.titleLabel?.font = .systemFont(ofSize: 12.0)
     $0.setTitle(Strings.CheckAgain, for: .normal)
     $0.setContentHuggingPriority(.required, for: .horizontal)
-    $0.loaderView = LoaderView(size: .small)
+  }
+  
+  private let checkAgainLoaderView = LoaderView(size: .small).then {
+    $0.alpha = 0.0
   }
   
   // Only shown when unverified
@@ -145,9 +148,15 @@ class PublisherView: UIStackView {
     verifiedLabelStackView.addArrangedSubview(verifiedCheckAgainStackView)
     verifiedCheckAgainStackView.addArrangedSubview(verifiedLabel)
     verifiedCheckAgainStackView.addArrangedSubview(checkAgainButton)
+    verifiedCheckAgainStackView.addSubview(checkAgainLoaderView)
     
     faviconImageView.snp.makeConstraints {
       $0.size.equalTo(UX.faviconSize)
+    }
+    
+    checkAgainLoaderView.snp.makeConstraints {
+      $0.centerY.equalTo(checkAgainButton)
+      $0.right.equalTo(checkAgainButton.snp.right)
     }
     
     checkAgainButton.addTarget(self, action: #selector(onCheckAgainPressed(_:)), for: .touchUpInside)
@@ -156,5 +165,28 @@ class PublisherView: UIStackView {
   @objc
   private func onCheckAgainPressed(_ button: Button) {
     onCheckAgainTapped?()
+  }
+  
+  func setCheckAgainIsLoading(_ loading: Bool) {
+    let animatingOutView = loading ? checkAgainButton : checkAgainLoaderView
+    let animatingInView = loading ? checkAgainLoaderView : checkAgainButton
+    
+    if loading {
+      checkAgainLoaderView.start()
+    }
+    
+    UIView.animateKeyframes(withDuration: 0.45, delay: 0, options: [], animations: {
+      UIView.addKeyframe(withRelativeStartTime: 0, relativeDuration: 0.2, animations: {
+        animatingOutView.alpha = 0.0
+      })
+      UIView.addKeyframe(withRelativeStartTime: 0.25, relativeDuration: 0.2, animations: {
+        animatingInView.alpha = 1.0
+      })
+    }, completion: { _ in
+      if !loading {
+        self.checkAgainLoaderView.stop()
+        self.checkAgainLoaderView.alpha = 0.0
+      }
+    })
   }
 }

--- a/BraveRewardsUI/Settings/Auto-Contribute/Settings/AutoContributeSettingsViewController.swift
+++ b/BraveRewardsUI/Settings/Auto-Contribute/Settings/AutoContributeSettingsViewController.swift
@@ -96,24 +96,17 @@ extension AutoContributeSettingsViewController: UITableViewDelegate, UITableView
     case .monthlyPayment:
       guard let wallet = ledger.walletInfo else { break }
       let monthlyPayment = ledger.contributionAmount
-      let choices = wallet.parametersChoices.map { $0.doubleValue }
-      let selectedIndex = choices.index(of: monthlyPayment) ?? 0
-      let stringChoices = choices.map { choice -> String in
-        var amount = "\(choice) BAT"
-        if let dollarRate = ledger.dollarStringForBATAmount(choice) {
-          amount.append(" (\(dollarRate))")
+      let choices = wallet.parametersChoices.map { BATValue($0.doubleValue) }
+      let selectedIndex = choices.map({ $0.doubleValue }).index(of: monthlyPayment) ?? 0
+      
+      let controller = BATValueOptionsSelectionViewController(ledger: ledger, options: choices, selectedOptionIndex: selectedIndex) { [weak self] (selectedIndex) in
+        guard let self = self else { return }
+        if selectedIndex < choices.count {
+          self.ledger.contributionAmount = choices[selectedIndex].doubleValue
         }
-        return amount
+        self.navigationController?.popViewController(animated: true)
       }
-      let controller = OptionsSelectionViewController(
-        options: stringChoices,
-        selectedOptionIndex: selectedIndex) { [weak self] (selectedIndex) in
-          guard let self = self else { return }
-          if selectedIndex < choices.count {
-            self.ledger.contributionAmount = choices[selectedIndex]
-          }
-          self.navigationController?.popViewController(animated: true)
-      }
+      
       controller.title = Strings.AutoContributeMonthlyPayment
       navigationController?.pushViewController(controller, animated: true)
     case .minimumLength:

--- a/BraveRewardsUI/Settings/Options/OptionsSelectionViewController.swift
+++ b/BraveRewardsUI/Settings/Options/OptionsSelectionViewController.swift
@@ -15,9 +15,9 @@ extension String: DisplayableOption {
 }
 
 /// A view controller which allows a user to select a single option from a set
-class OptionsSelectionViewController: UIViewController {
+class OptionsSelectionViewController<OptionType: DisplayableOption>: UIViewController, UITableViewDelegate, UITableViewDataSource {
   /// The list of options
-  let options: [DisplayableOption]
+  let options: [OptionType]
   /// The selected option's index
   private(set) var selectedOptionIndex: Int {
     didSet {
@@ -30,7 +30,7 @@ class OptionsSelectionViewController: UIViewController {
   /// A closure executed when the user taps on an option
   let optionSelected: (Int) -> Void
   
-  init(options: [DisplayableOption],
+  init(options: [OptionType],
        selectedOptionIndex: Int = 0,
        optionSelected: @escaping (_ selectedIndex: Int) -> Void) {
     self.options = options
@@ -59,16 +59,17 @@ class OptionsSelectionViewController: UIViewController {
     contentView.tableView.delegate = self
     contentView.tableView.dataSource = self
   }
-}
-
-extension OptionsSelectionViewController: UITableViewDelegate {
+  
+  // MARK: - Delegate
+  
   func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
     selectedOptionIndex = indexPath.row
     optionSelected(selectedOptionIndex)
     tableView.deselectRow(at: indexPath, animated: true)
   }
-}
-extension OptionsSelectionViewController: UITableViewDataSource {
+  
+  // MARK: - DataSource
+  
   func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
     return options.count
   }

--- a/BraveRewardsUI/Tipping/TippingSelectionViewController.swift
+++ b/BraveRewardsUI/Tipping/TippingSelectionViewController.swift
@@ -1,0 +1,65 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import Foundation
+import UIKit
+import BraveRewards
+
+class TippingSelectionViewController: OptionsSelectionViewController {
+  
+  private let state: RewardsState?
+  
+  // Hide the super constructor with `DisplayableOption`
+  // in favour of our constructor with `BatValue`
+  private override init(options: [DisplayableOption],
+                        selectedOptionIndex: Int = 0,
+                        optionSelected: @escaping (_ selectedIndex: Int) -> Void) {
+    self.state = nil
+    super.init(options: options, selectedOptionIndex: selectedOptionIndex, optionSelected: optionSelected)
+  }
+  
+  init(state: RewardsState, options: [BATValue],
+       selectedOptionIndex: Int = 0,
+       optionSelected: @escaping (_ selectedIndex: Int) -> Void) {
+    self.state = state
+    super.init(options: options, selectedOptionIndex: selectedOptionIndex, optionSelected: optionSelected)
+  }
+  
+  override func viewDidLoad() {
+    super.viewDidLoad()
+    
+    self.title = "Recurring Tips"
+  }
+  
+  override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+    let cell = tableView.dequeueReusableCell(withIdentifier: "OptionCell", for: indexPath)
+    cell.textLabel?.text = options[indexPath.row].displayString
+    cell.textLabel?.font = .systemFont(ofSize: 14.0)
+    cell.textLabel?.textColor = Colors.grey100
+    cell.textLabel?.numberOfLines = 0
+    cell.accessoryType = selectedOptionIndex == indexPath.row ? .checkmark : .none
+    
+    guard let options = options as? [BATValue] else { return cell }
+    let displayString = options[indexPath.row].displayString
+    let dollarAmount = state?.ledger.dollarStringForBATAmount(options[indexPath.row].doubleValue) ?? ""
+    
+    let attributedText = NSMutableAttributedString(string: displayString, attributes: [
+      .foregroundColor: Colors.grey100,
+      .font: UIFont.systemFont(ofSize: 14.0, weight: .medium)
+    ])
+    
+    attributedText.append(NSAttributedString(string: " BAT", attributes: [
+      .foregroundColor: Colors.grey200,
+      .font: UIFont.systemFont(ofSize: 12.0)
+    ]))
+    
+    attributedText.append(NSAttributedString(string: " (\(dollarAmount))", attributes: [
+      .foregroundColor: Colors.grey200,
+      .font: UIFont.systemFont(ofSize: 10.0)
+    ]))
+    
+    cell.textLabel?.attributedText = attributedText
+    return cell
+  }
+}

--- a/BraveRewardsUI/Tipping/TippingSelectionViewController.swift
+++ b/BraveRewardsUI/Tipping/TippingSelectionViewController.swift
@@ -6,43 +6,28 @@ import Foundation
 import UIKit
 import BraveRewards
 
-class TippingSelectionViewController: OptionsSelectionViewController {
+class BATValueOptionsSelectionViewController: OptionsSelectionViewController<BATValue> {
   
-  private let state: RewardsState?
+  private let ledger: BraveLedger?
   
-  // Hide the super constructor with `DisplayableOption`
-  // in favour of our constructor with `BatValue`
-  private override init(options: [DisplayableOption],
-                        selectedOptionIndex: Int = 0,
-                        optionSelected: @escaping (_ selectedIndex: Int) -> Void) {
-    self.state = nil
-    super.init(options: options, selectedOptionIndex: selectedOptionIndex, optionSelected: optionSelected)
-  }
-  
-  init(state: RewardsState, options: [BATValue],
+  init(ledger: BraveLedger, options: [BATValue],
        selectedOptionIndex: Int = 0,
        optionSelected: @escaping (_ selectedIndex: Int) -> Void) {
-    self.state = state
+    self.ledger = ledger
     super.init(options: options, selectedOptionIndex: selectedOptionIndex, optionSelected: optionSelected)
   }
   
   override func viewDidLoad() {
     super.viewDidLoad()
     
-    self.title = "Recurring Tips"
+    self.title = Strings.RecurringTipTitle
   }
   
   override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
-    let cell = tableView.dequeueReusableCell(withIdentifier: "OptionCell", for: indexPath)
-    cell.textLabel?.text = options[indexPath.row].displayString
-    cell.textLabel?.font = .systemFont(ofSize: 14.0)
-    cell.textLabel?.textColor = Colors.grey100
-    cell.textLabel?.numberOfLines = 0
-    cell.accessoryType = selectedOptionIndex == indexPath.row ? .checkmark : .none
-    
-    guard let options = options as? [BATValue] else { return cell }
+    let cell = super.tableView(tableView, cellForRowAt: indexPath)
+
     let displayString = options[indexPath.row].displayString
-    let dollarAmount = state?.ledger.dollarStringForBATAmount(options[indexPath.row].doubleValue) ?? ""
+    let dollarAmount = ledger?.dollarStringForBATAmount(options[indexPath.row].doubleValue) ?? ""
     
     let attributedText = NSMutableAttributedString(string: displayString, attributes: [
       .foregroundColor: Colors.grey100,

--- a/BraveRewardsUI/Tipping/TippingSelectionViewController.swift
+++ b/BraveRewardsUI/Tipping/TippingSelectionViewController.swift
@@ -6,6 +6,8 @@ import Foundation
 import UIKit
 import BraveRewards
 
+/// A controller for displaying BATValue options with their equivalent dollar value.
+/// When the user selects an option, the selected index is returned in the completion block.
 class BATValueOptionsSelectionViewController: OptionsSelectionViewController<BATValue> {
   
   private let ledger: BraveLedger?

--- a/BraveRewardsUI/Tipping/TippingViewController.swift
+++ b/BraveRewardsUI/Tipping/TippingViewController.swift
@@ -28,7 +28,7 @@ class TippingViewController: UIViewController, UIViewControllerTransitioningDele
   
   let state: RewardsState
   let publisherInfo: PublisherInfo
-  private static let defaultTippingAmounts = [1.0, 5.0, 10.0]
+  static let defaultTippingAmounts = [1.0, 5.0, 10.0]
   
   init(state: RewardsState, publisherInfo: PublisherInfo) {
     self.state = state

--- a/BraveRewardsUI/Wallet/WalletViewController.swift
+++ b/BraveRewardsUI/Wallet/WalletViewController.swift
@@ -219,16 +219,25 @@ class WalletViewController: UIViewController, RewardsSummaryProtocol {
       }
       
       publisherView.onCheckAgainTapped = { [weak self] in
+        publisherView.setCheckAgainIsLoading(true)
+        let date = Date()
+        
         self?.state.ledger.refreshPublisher(withId: host, completion: { isVerified in
           
-          // I am only adding this delay because of ticket: brave-ios/issues/1236
-          // Desktop is apparently doing this as well..
-          // - Brandon T.
-          DispatchQueue.main.asyncAfter(deadline: .now() + 2.5, execute: {
-            publisherView.checkAgainButton.isLoading = false
+          let updateStates = {
+            publisherView.setCheckAgainIsLoading(false)
             publisherView.checkAgainButton.isHidden = true
             publisherView.setVerified(isVerified)
-          })
+          }
+          
+          //Fixes brave-rewards-ios/issues/134
+          if isVerified || Date().timeIntervalSince(date) > 2.5 {
+            updateStates()
+          } else {
+            DispatchQueue.main.asyncAfter(deadline: .now() + 2.5, execute: {
+              updateStates()
+            })
+          }
         })
       }
       

--- a/BraveRewardsUI/Wallet/WalletViewController.swift
+++ b/BraveRewardsUI/Wallet/WalletViewController.swift
@@ -14,6 +14,7 @@ protocol WalletContentView: AnyObject {
 class WalletViewController: UIViewController, RewardsSummaryProtocol {
   
   let state: RewardsState
+  private var recurringTipAmount: Double = 0.0
   
   init(state: RewardsState) {
     self.state = state
@@ -159,7 +160,7 @@ class WalletViewController: UIViewController, RewardsSummaryProtocol {
     publisherSummaryView.monthlyTipView.addTarget(self, action: #selector(tappedMonthlyTip), for: .touchUpInside)
     
     publisherSummaryView.monthlyTipView.isHidden = true
-    publisherSummaryView.monthlyTipView.batValueView.amountLabel.text = "5"
+    publisherSummaryView.monthlyTipView.batValueView.amountLabel.text = "\(Int(self.recurringTipAmount))"
     
     let publisherView = publisherSummaryView.publisherView
     let attentionView = publisherSummaryView.attentionView
@@ -208,6 +209,7 @@ class WalletViewController: UIViewController, RewardsSummaryProtocol {
         
         guard let contributionAmount = recurringTip.contributions.first?.value else { return }
         
+        self.recurringTipAmount = contributionAmount
         self.publisherSummaryView.monthlyTipView.batValueView.amountLabel.text = "\(Int(contributionAmount))"
         self.publisherSummaryView.monthlyTipView.isHidden = false
       }
@@ -315,23 +317,37 @@ class WalletViewController: UIViewController, RewardsSummaryProtocol {
   }
   
   @objc private func tappedMonthlyTip() {
-    // TODO: Replace with actual values.
-    let options = [
-      BATValue(1),
-      BATValue(5),
-      BATValue(10)
-    ]
-    let optionsVC = OptionsSelectionViewController(options: options, selectedOptionIndex: 1, optionSelected: { [weak self] index in
-      // TODO: save selection and update UI
-      guard let self = self else {
-        return
+    guard let host = state.url.host else { return }
+    state.ledger.publisherBanner(forId: host, completion: { [weak self] banner in
+      guard let self = self else { return }
+      
+      var options = TippingViewController.defaultTippingAmounts.map({ BATValue($0) })
+      if let banner = banner, !banner.amounts.isEmpty {
+        options = banner.amounts.map({ BATValue($0.doubleValue) })
       }
-      self.navigationController?.popToViewController(self, animated: true)
-      // swiftlint:ignore:next
-      self.publisherSummaryView.monthlyTipView.batValueView.amountLabel.text = options[safe: index]?.displayString ?? options[0].displayString
+      
+      options.insert(BATValue(0.0), at: 0)
+      
+      let selectedIndex = options.firstIndex(where: { Int($0.doubleValue) == Int(self.recurringTipAmount) }) ?? 0
+      
+      let optionsVC = TippingSelectionViewController(state: self.state, options: options, selectedOptionIndex: selectedIndex, optionSelected: { [weak self] optionIndex in
+        guard let self = self else { return }
+        
+        self.recurringTipAmount = options[optionIndex].doubleValue
+        
+        self.navigationController?.popToViewController(self, animated: true)
+        // swiftlint:ignore:next
+        self.publisherSummaryView.monthlyTipView.batValueView.amountLabel.text = options[safe: optionIndex]?.displayString ?? options[0].displayString
+        
+        // The user decided to remove an existing tip.
+        if optionIndex == 0 && selectedIndex > 0 {
+          self.state.ledger.removeRecurringTip(publisherId: host)
+          self.publisherSummaryView.monthlyTipView.isHidden = true
+        }
+      })
+      
+      self.navigationController?.pushViewController(optionsVC, animated: true)
     })
-    
-    self.navigationController?.pushViewController(optionsVC, animated: true)
   }
   
   @objc private func tappedEnableBraveRewards() {

--- a/BraveRewardsUI/Wallet/WalletViewController.swift
+++ b/BraveRewardsUI/Wallet/WalletViewController.swift
@@ -330,7 +330,7 @@ class WalletViewController: UIViewController, RewardsSummaryProtocol {
       
       let selectedIndex = options.firstIndex(where: { Int($0.doubleValue) == Int(self.recurringTipAmount) }) ?? 0
       
-      let optionsVC = TippingSelectionViewController(state: self.state, options: options, selectedOptionIndex: selectedIndex, optionSelected: { [weak self] optionIndex in
+      let optionsVC = BATValueOptionsSelectionViewController(ledger: self.state.ledger, options: options, selectedOptionIndex: selectedIndex, optionSelected: { [weak self] optionIndex in
         guard let self = self else { return }
         
         self.recurringTipAmount = options[optionIndex].doubleValue
@@ -340,7 +340,7 @@ class WalletViewController: UIViewController, RewardsSummaryProtocol {
         self.publisherSummaryView.monthlyTipView.batValueView.amountLabel.text = options[safe: optionIndex]?.displayString ?? options[0].displayString
         
         // The user decided to remove an existing tip.
-        if optionIndex == 0 && selectedIndex > 0 {
+        if Int(self.recurringTipAmount) == 0 {
           self.state.ledger.removeRecurringTip(publisherId: host)
           self.publisherSummaryView.monthlyTipView.isHidden = true
         }


### PR DESCRIPTION
Updated tipping selection to maintain state between screens when a tip is selected.
Updated tipping selection to allow the user to remove a tip by selecting "0 BAT".
Updated tipping selection screen to show the currency and have a title.

Fixes https://github.com/brave/brave-rewards-ios/issues/126
Fixes https://github.com/brave/brave-rewards-ios/issues/127
Fixes https://github.com/brave/brave-rewards-ios/issues/129
Fixes https://github.com/brave/brave-rewards-ios/issues/134