### PR TITLE
Fix #138: Set up publisher view only once.

### DIFF
--- a/BraveRewardsUI/Wallet/WalletViewController.swift
+++ b/BraveRewardsUI/Wallet/WalletViewController.swift
@@ -88,6 +88,7 @@ class WalletViewController: UIViewController, RewardsSummaryProtocol {
     rewardsSummaryView.rows = summaryRows
     
     reloadUIState()
+    setupPublisherView(publisherSummaryView)
     view.layoutIfNeeded()
   }
   
@@ -150,7 +151,7 @@ class WalletViewController: UIViewController, RewardsSummaryProtocol {
   
   // MARK: -
   
-  private lazy var publisherSummaryView = PublisherSummaryView().then(setupPublisherView)
+  private lazy var publisherSummaryView = PublisherSummaryView()
   private lazy var rewardsDisabledView = RewardsDisabledView().then {
     $0.termsOfServiceLabel.onLinkedTapped = tappedDisclaimerLink
   }


### PR DESCRIPTION
This line 

https://github.com/iccub/brave-rewards-ios/blob/38dd2d3acf1bac1684a7dcebfeea1d6dc41c89d7/BraveRewardsUI/Wallet/WalletViewController.swift#L204

was causing publisher set up to be called recursively, apparently `then` syntax doesn't get called only once with lazy variables?