### PR TITLE
Update BraveRewards framework with observers API

### DIFF
--- a/BraveRewardsExample/ViewController.swift
+++ b/BraveRewardsExample/ViewController.swift
@@ -139,7 +139,8 @@ class ViewController: UIViewController {
       let url = URL(string: ViewController.testPublisherURL)!
       rewards.ledger.publisherActivity(from: url, faviconURL: url, publisherBlob: "")
     } else {
-      rewards = BraveRewards(configuration: .default, delegate: self)
+      rewards = BraveRewards(configuration: .default)
+      rewards.delegate = self
     }
   }
 

--- a/BraveRewardsUI/Wallet/WalletViewController.swift
+++ b/BraveRewardsUI/Wallet/WalletViewController.swift
@@ -412,7 +412,7 @@ extension WalletViewController {
   func startNotificationObserver() {
     // Stopping as a precaution
     // Add observer
-    NotificationCenter.default.addObserver(self, selector: #selector(notificationAdded(_:)), name: NSNotification.Name.BATBraveLedgerNotificationAdded, object: nil)
+    NotificationCenter.default.addObserver(self, selector: #selector(notificationAdded(_:)), name: BraveLedger.NotificationAdded, object: nil)
     loadNextNotification()
   }
   

--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@ A UI framework for consuming Brave Rewards on [brave-ios](https://github.com/bra
 The latest BraveRewards.framework was built on:
 
 ```
-brave-browser/9880c52d97eae63d560c59e409d43e4c6847757c
-brave-core/b0e1645f9021bd0ee62fe28264e43313f84aae21
+brave-browser/c4c4073fe5ab1347d79599c5e5df81387dd919da
+brave-core/6a12246d3893108b3064255e6d21984cc57780d8
 ```
 
 Building the code

--- a/lib/BraveRewards.framework/Headers/BATAdsNotification.h
+++ b/lib/BraveRewards.framework/Headers/BATAdsNotification.h
@@ -16,6 +16,7 @@ typedef NS_ENUM(NSInteger, BATAdsConfirmationType) {
 
 NS_SWIFT_NAME(AdsNotification)
 @interface BATAdsNotification : NSObject
+@property (nonatomic, readonly, copy) NSString *id;
 @property (nonatomic, readonly, copy) NSString *creativeSetID;
 @property (nonatomic, readonly, copy) NSString *category;
 @property (nonatomic, readonly, copy) NSString *advertiser;

--- a/lib/BraveRewards.framework/Headers/BATBraveAds.h
+++ b/lib/BraveRewards.framework/Headers/BATBraveAds.h
@@ -49,7 +49,7 @@ NS_SWIFT_NAME(BraveAds)
 @property (nonatomic, readonly) NSArray<NSString *> *supportedLocales;
 
 /// Remove all cached history (should be called when the user clears their browser history)
-- (void)removeAllHistory;
+- (void)removeAllHistory:(void (^)(BOOL))completion;
 
 /// Should be called when the user invokes "Show Sample Ad" on the Client; a Notification is then sent
 /// to the Client for processing

--- a/lib/BraveRewards.framework/Headers/BATBraveLedger.h
+++ b/lib/BraveRewards.framework/Headers/BATBraveLedger.h
@@ -7,6 +7,7 @@
 #import "ledger.mojom.objc.h"
 #import "BATActivityInfoFilter.h"
 #import "BATRewardsNotification.h"
+#import "BATBraveLedgerObserver.h"
 
 @class BATBraveAds;
 
@@ -17,7 +18,7 @@ typedef void (^BATFaviconFetcher)(NSURL *pageURL, void (^completion)(NSURL * _Nu
 /// The error domain for ledger related errors
 extern NSString * const BATBraveLedgerErrorDomain NS_SWIFT_NAME(BraveLedgerErrorDomain);
 
-extern NSNotificationName const BATBraveLedgerNotificationAdded;
+extern NSNotificationName const BATBraveLedgerNotificationAdded NS_SWIFT_NAME(BraveLedger.NotificationAdded);
 
 NS_SWIFT_NAME(BraveLedger)
 @interface BATBraveLedger : NSObject
@@ -30,6 +31,16 @@ NS_SWIFT_NAME(BraveLedger)
 - (instancetype)initWithStateStoragePath:(NSString *)path;
 
 - (instancetype)init NS_UNAVAILABLE;
+
+#pragma mark - Observers
+
+/// Add an interface to the list of observers
+///
+/// Observers are stored weakly and do not necessarily need to be removed
+- (void)addObserver:(BATBraveLedgerObserver *)observer;
+
+/// Removes an interface from the list of observers
+- (void)removeObserver:(BATBraveLedgerObserver *)observer;
 
 #pragma mark - Global
 
@@ -91,13 +102,25 @@ NS_SWIFT_NAME(BraveLedger)
 
 #pragma mark - Publishers
 
+/// Get publisher info based on its publisher key.
+///
+/// This key is _not_ always the URL's host. Use `publisherActivityFromURL`
+/// instead when obtaining a publisher given a URL
+///
+/// @note `completion` callback is called synchronously
 - (void)publisherInfoForId:(NSString *)publisherId
-                completion:(void (^)(BATPublisherInfo * _Nullable info))completion;
+                completion:(void (NS_NOESCAPE ^)(BATPublisherInfo * _Nullable info))completion;
 
+/// Get publisher info & its activity based on its publisher key
+///
+/// This key is _not_ always the URL's host. Use `publisherActivityFromURL`
+/// instead when obtaining a publisher given a URL
+///
+/// @note `completion` callback is called synchronously
 - (void)listActivityInfoFromStart:(unsigned int)start
                             limit:(unsigned int)limit
                            filter:(BATActivityInfoFilter *)filter
-                       completion:(void (^)(NSArray<BATPublisherInfo *> *))completion;
+                       completion:(void (NS_NOESCAPE ^)(NSArray<BATPublisherInfo *> *))completion;
 
 - (void)publisherActivityFromURL:(NSURL *)URL
                       faviconURL:(nullable NSURL *)faviconURL
@@ -116,8 +139,14 @@ NS_SWIFT_NAME(BraveLedger)
 
 @property (nonatomic, readonly) NSUInteger numberOfExcludedPublishers;
 
+/// Get the publisher banner given some publisher key
+///
+/// This key is _not_ always the URL's host. Use `publisherActivityFromURL`
+/// instead when obtaining a publisher given a URL
+///
+/// @note `completion` callback is called synchronously
 - (void)publisherBannerForId:(NSString *)publisherId
-                  completion:(void (^)(BATPublisherBanner * _Nullable banner))completion;
+                  completion:(void (NS_NOESCAPE ^)(BATPublisherBanner * _Nullable banner))completion;
 
 /// Refresh a publishers verification status
 - (void)refreshPublisherWithId:(NSString *)publisherId
@@ -125,14 +154,20 @@ NS_SWIFT_NAME(BraveLedger)
 
 #pragma mark - Tips
 
-- (void)listRecurringTips:(void (^)(NSArray<BATPublisherInfo *> *))completion;
+/// Get a list of publishers who the user has recurring tips on
+///
+/// @note `completion` callback is called synchronously
+- (void)listRecurringTips:(void (NS_NOESCAPE ^)(NSArray<BATPublisherInfo *> *))completion;
 
 - (void)addRecurringTipToPublisherWithId:(NSString *)publisherId
                                   amount:(double)amount NS_SWIFT_NAME(addRecurringTip(publisherId:amount:));
 
 - (void)removeRecurringTipForPublisherWithId:(NSString *)publisherId NS_SWIFT_NAME(removeRecurringTip(publisherId:));
 
-- (void)listOneTimeTips:(void (^)(NSArray<BATPublisherInfo *> *))completion;
+/// Get a list of publishers who the user has made direct tips too
+///
+/// @note `completion` callback is called synchronously
+- (void)listOneTimeTips:(void (NS_NOESCAPE ^)(NSArray<BATPublisherInfo *> *))completion;
 
 - (void)tipPublisherDirectly:(BATPublisherInfo *)publisher
                       amount:(int)amount

--- a/lib/BraveRewards.framework/Headers/BATBraveLedgerObserver.h
+++ b/lib/BraveRewards.framework/Headers/BATBraveLedgerObserver.h
@@ -1,0 +1,69 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#import <Foundation/Foundation.h>
+#import "ledger.mojom.objc.h"
+#import "Enums.h"
+
+@class BATBraveLedger;
+
+NS_ASSUME_NONNULL_BEGIN
+
+/// A ledger observer can get notified when certain actions happen
+///
+/// Creating a LedgerObserver alone will not respond to any events. Set
+/// each closure that you wish to watch based on the data being displayed on
+/// screen
+NS_SWIFT_NAME(LedgerObserver)
+@interface BATBraveLedgerObserver : NSObject
+
+@property (nonatomic, readonly, weak) BATBraveLedger *ledger;
+
+- (instancetype)initWithLedger:(BATBraveLedger *)ledger;
+
+/// Rewards was enabled or disabled globally
+@property (nonatomic, copy, nullable) void (^rewardsEnabledStateUpdated)(BOOL enabled);
+
+/// Executed when the wallet is first initialized
+@property (nonatomic, copy, nullable) void (^walletInitalized)(BATResult result);
+
+/// An eligable grant was added to the wallet
+@property (nonatomic, copy, nullable) void (^grantAdded)(BATGrant *grant);
+
+/// A grant was claimed
+@property (nonatomic, copy, nullable) void (^grantClaimed)(BATGrant *grant);
+
+/// A reconcile transaction completed and the user may have an updated balance
+/// and likely an updated balance report
+@property (nonatomic, copy, nullable) void (^reconcileCompleted)(BATResult result,
+                                                                 NSString *viewingId,
+                                                                 BATRewardsCategory category,
+                                                                 NSString *probi);
+
+/// The users balance report has been updated
+@property (nonatomic, copy, nullable) void (^balanceReportUpdated)();
+
+/// The exclusion state of a given publisher has been changed
+@property (nonatomic, copy, nullable) void (^excludedSitesChanged)(NSString *publisherKey, BATPublisherExclude excluded);
+
+/// confirmationsTransactionHistoryDidChange
+@property (nonatomic, copy, nullable) void (^confirmationsTransactionHistoryDidChange)();
+
+/// The publisher list was normalized and saved
+@property (nonatomic, copy, nullable) void (^publisherListNormalized)(NSArray<BATPublisherInfo *> *normalizedList);
+
+@property (nonatomic, copy, nullable) void (^pendingContributionAdded)(NSString *publisherKey);
+
+@property (nonatomic, copy, nullable) void (^pendingContributionsRemoved)(NSArray<NSString *> *publisherKeys);
+
+@property (nonatomic, copy, nullable) void (^recurringTipAdded)(NSString *publisherKey);
+
+@property (nonatomic, copy, nullable) void (^recurringTipRemoved)(NSString *publisherKey);
+
+// A users contribution was added
+@property (nonatomic, copy, nullable) void (^contributionAdded)(BOOL successful, BATRewardsCategory category);
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/lib/BraveRewards.framework/Headers/BATBraveRewards.h
+++ b/lib/BraveRewards.framework/Headers/BATBraveRewards.h
@@ -68,11 +68,10 @@ NS_SWIFT_NAME(BraveRewards)
 - (void)reset;
 
 /// Create a BraveRewards instance with a given configuration
-- (instancetype)initWithConfiguration:(BATBraveRewardsConfiguration *)configuration
-                             delegate:(id<BATBraveRewardsDelegate>)delegate;
+- (instancetype)initWithConfiguration:(BATBraveRewardsConfiguration *)configuration;
 /// Create a BraveRewards instance with a given configuration and custom ledger classes for mocking
 - (instancetype)initWithConfiguration:(BATBraveRewardsConfiguration *)configuration
-                             delegate:(id<BATBraveRewardsDelegate>)delegate
+                             delegate:(nullable id<BATBraveRewardsDelegate>)delegate
                           ledgerClass:(nullable Class)ledgerClass
                              adsClass:(nullable Class)adsClass NS_DESIGNATED_INITIALIZER;
 - (instancetype)init NS_UNAVAILABLE;

--- a/lib/BraveRewards.framework/Headers/Enums.h
+++ b/lib/BraveRewards.framework/Headers/Enums.h
@@ -1,6 +1,4 @@
-/* WARNING: THIS FILE IS GENERATED. ANY CHANGES TO THIS FILE WILL BE OVERWRITTEN
- *
- * This Source Code Form is subject to the terms of the Mozilla Public
+/* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 

--- a/lib/BraveRewards.framework/Headers/Records.h
+++ b/lib/BraveRewards.framework/Headers/Records.h
@@ -1,25 +1,13 @@
-/* WARNING: THIS FILE IS GENERATED. ANY CHANGES TO THIS FILE WILL BE OVERWRITTEN
- *
- * This Source Code Form is subject to the terms of the Mozilla Public
+/* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 #import <Foundation/Foundation.h>
 #import "Enums.h"
 
-@class BATAutoContributeProps, BATBalanceReportInfo, BATPublisherBanner, BATReconcileInfo, BATRewardsInternalsInfo, BATTransactionInfo, BATTransactionsInfo, BATMediaEventInfo;
+@class BATBalanceReportInfo, BATReconcileInfo, BATRewardsInternalsInfo, BATTransactionInfo, BATTransactionsInfo, BATMediaEventInfo;
 
 NS_ASSUME_NONNULL_BEGIN
-
-NS_SWIFT_NAME(AutoContributeProps)
-@interface BATAutoContributeProps : NSObject
-@property (nonatomic) bool enabledContribute;
-@property (nonatomic) unsigned long long contributionMinTime;
-@property (nonatomic) int contributionMinVisits;
-@property (nonatomic) bool contributionNonVerified;
-@property (nonatomic) bool contributionVideos;
-@property (nonatomic) unsigned long long reconcileStamp;
-@end
 
 NS_SWIFT_NAME(BalanceReportInfo)
 @interface BATBalanceReportInfo : NSObject
@@ -32,20 +20,6 @@ NS_SWIFT_NAME(BalanceReportInfo)
 @property (nonatomic) NSString * recurringDonation;
 @property (nonatomic) NSString * oneTimeDonation;
 @property (nonatomic) NSString * total;
-@end
-
-NS_SWIFT_NAME(PublisherBanner)
-@interface BATPublisherBanner : NSObject
-@property (nonatomic) NSString * publisherKey;
-@property (nonatomic) NSString * title;
-@property (nonatomic) NSString * name;
-@property (nonatomic) NSString * desc;
-@property (nonatomic) NSString * background;
-@property (nonatomic) NSString * logo;
-@property (nonatomic) NSArray<NSNumber *> * amounts;
-@property (nonatomic) NSString * provider;
-@property (nonatomic) NSDictionary<NSString *, NSString *> * social;
-@property (nonatomic) bool verified;
 @end
 
 NS_SWIFT_NAME(ReconcileInfo)

--- a/lib/BraveRewards.framework/Headers/ledger.mojom.objc.h
+++ b/lib/BraveRewards.framework/Headers/ledger.mojom.objc.h
@@ -12,7 +12,7 @@
 
 
 
-@class BATContributionInfo, BATPublisherInfo, BATPendingContribution, BATPendingContributionInfo, BATVisitData, BATGrant, BATWalletProperties, BATBalance;
+@class BATContributionInfo, BATPublisherInfo, BATPublisherBanner, BATPendingContribution, BATPendingContributionInfo, BATVisitData, BATGrant, BATWalletProperties, BATBalance, BATAutoContributeProps;
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -40,6 +40,20 @@ NS_SWIFT_NAME(PublisherInfo)
 @property (nonatomic, copy) NSString * provider;
 @property (nonatomic, copy) NSString * faviconUrl;
 @property (nonatomic, copy) NSArray<BATContributionInfo *> * contributions;
+@end
+
+NS_SWIFT_NAME(PublisherBanner)
+@interface BATPublisherBanner : NSObject <NSCopying>
+@property (nonatomic, copy) NSString * publisherKey;
+@property (nonatomic, copy) NSString * title;
+@property (nonatomic, copy) NSString * name;
+@property (nonatomic, copy) NSString * desc;
+@property (nonatomic, copy) NSString * background;
+@property (nonatomic, copy) NSString * logo;
+@property (nonatomic, copy) NSArray<NSNumber *> * amounts;
+@property (nonatomic, copy) NSString * provider;
+@property (nonatomic, copy) NSDictionary<NSString *, NSString *> * social;
+@property (nonatomic) bool verified;
 @end
 
 NS_SWIFT_NAME(PendingContribution)
@@ -101,6 +115,16 @@ NS_SWIFT_NAME(Balance)
 @property (nonatomic) double total;
 @property (nonatomic, copy) NSDictionary<NSString *, NSNumber *> * rates;
 @property (nonatomic, copy) NSDictionary<NSString *, NSNumber *> * wallets;
+@end
+
+NS_SWIFT_NAME(AutoContributeProps)
+@interface BATAutoContributeProps : NSObject <NSCopying>
+@property (nonatomic) bool enabledContribute;
+@property (nonatomic) uint64_t contributionMinTime;
+@property (nonatomic) int32_t contributionMinVisits;
+@property (nonatomic) bool contributionNonVerified;
+@property (nonatomic) bool contributionVideos;
+@property (nonatomic) uint64_t reconcileStamp;
 @end
 
 NS_ASSUME_NONNULL_END


### PR DESCRIPTION
Adds support for new observer API changes

[Library changset](https://github.com/brave/brave-core/commits/master/vendor/brave-ios):

- Add callback to LoadLedgerState and LoadPublisherState https://github.com/brave/brave-core/pull/2910
- Move BATBraveRewards delegate init outside of constructor https://github.com/brave/brave-core/pull/2949
- Migrate brave-core changes from Android Ads https://github.com/brave/brave-core/pull/2947
- Add prefs support for ads https://github.com/brave/brave-core/pull/2162
- refactor GetAutoContributeProps to return pointer https://github.com/brave/brave-core/pull/2937
- Add ledger observer to receive notification of LedgerClient methods https://github.com/brave/brave-core/pull/2922
- move AutoContributeProps to mojo interface https://github.com/brave/brave-core/pull/2884
- Update public calls with notes about synchronous behaviour & pub keys https://github.com/brave/brave-core/pull/2902
- Make sure to update persisted notifications when clearing them https://github.com/brave/brave-core/pull/2900
- Generate method to convert Obj-C mojo to original C++ mojo struct https://github.com/brave/brave-core/pull/2882
- move PublisherBanner to mojo type https://github.com/brave/brave-core/pull/2828

