### PR TITLE
No Bug: Update SnapKit to 5.0.1(Swift 5 compatibility).

### DIFF
--- a/BraveRewardsUI/Common/Tables/TableViewCell.swift
+++ b/BraveRewardsUI/Common/Tables/TableViewCell.swift
@@ -83,7 +83,7 @@ class TableViewCell: UITableViewCell, TableViewReusable {
   override func updateConstraints() {
     super.updateConstraints()
     
-    label.snp_remakeConstraints {
+    label.snp.remakeConstraints {
       $0.top.equalToSuperview().inset(layoutMargins.top)
       if let imageView = imageView, imageView.image != nil, imageView.superview != nil {
         $0.leading.equalTo(imageView.snp.trailing).offset(layoutMargins.left)

--- a/Cartfile
+++ b/Cartfile
@@ -1,2 +1,2 @@
-github "SnapKit/SnapKit" "4.2.0"
+github "SnapKit/SnapKit" "5.0.1"
 github "facebook/pop" "1.0.12"

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,2 +1,2 @@
-github "SnapKit/SnapKit" "4.2.0"
+github "SnapKit/SnapKit" "5.0.1"
 github "facebook/pop" "1.0.12"


### PR DESCRIPTION
This is required as we have to use the same SnapKit version on brave-ios and here.

Related ticket for upcoming Swift5 upgrade https://github.com/brave/brave-ios/pull/1154

After this one is merged. I will update SnapKit and rewards-ios dependencies in brave-ios