### PR TITLE
Show correct ads payout date & fix locale provided for supported regions

### DIFF
--- a/BraveRewardsUI/Localized Strings/Strings.swift
+++ b/BraveRewardsUI/Localized Strings/Strings.swift
@@ -137,7 +137,7 @@ public extension Strings {
   static let ThreeAdsPerHour = NSLocalizedString("BraveRewardsThreeAdsPerHour", bundle: Bundle.RewardsUI, value: "3 ads per hour", comment: "")
   static let FourAdsPerHour = NSLocalizedString("BraveRewardsFourAdsPerHour", bundle: Bundle.RewardsUI, value: "4 ads per hour", comment: "")
   static let FiveAdsPerHour = NSLocalizedString("BraveRewardsFiveAdsPerHour", bundle: Bundle.RewardsUI, value: "5 ads per hour", comment: "")
-  static let AdsPayoutDate = NSLocalizedString("BraveRewardsAdsPayoutDate", bundle: Bundle.RewardsUI, value: "Monthly, 5th", comment: "")
+  static let AdsPayoutDateFormat = NSLocalizedString("BraveRewardsAdsPayoutDateFormat", bundle: Bundle.RewardsUI, value: "MMM d", comment: "")
   static let TotalGrantsClaimed = NSLocalizedString("BraveRewardsTotalGrantsClaimed", bundle: Bundle.RewardsUI, value: "Total Grants Claimed", comment: "")
   static let EarningFromAds = NSLocalizedString("BraveRewardsEarningFromAds", bundle: Bundle.RewardsUI, value: "Earnings from Ads", comment: "")
   static let OneTimeTips = NSLocalizedString("BraveRewardsOneTimeTips", bundle: Bundle.RewardsUI, value: "One-Time Tips", comment: "")

--- a/BraveRewardsUI/Settings/SettingsViewController.swift
+++ b/BraveRewardsUI/Settings/SettingsViewController.swift
@@ -36,6 +36,8 @@ class SettingsViewController: UIViewController {
     
     preferredContentSize = CGSize(width: RewardsUX.preferredPanelSize.width, height: 750)
     
+    state.ledger.updateAdsRewards()
+    
     settingsView.do {
       $0.rewardsToggleSection.toggleSwitch.addTarget(self, action: #selector(rewardsSwitchValueChanged), for: .valueChanged)
       $0.grantSection.claimGrantButton.addTarget(self, action: #selector(tappedClaimGrant), for: .touchUpInside)
@@ -49,7 +51,7 @@ class SettingsViewController: UIViewController {
       let dollarString = state.ledger.dollarStringForBATAmount(state.ledger.balance?.total ?? 0) ?? ""
       $0.walletSection.setWalletBalance(state.ledger.balanceString, crypto: "BAT", dollarValue: dollarString)
       
-      if let regionCode = Locale.current.regionCode, !BraveAds.isSupportedRegion(regionCode) {
+      if !BraveAds.isSupportedRegion(Locale.current.identifier) {
          $0.adsSection.status = .unsupportedRegion
       }
       $0.adsSection.toggleSwitch.isOn = state.ads.isEnabled

--- a/BraveRewardsUI/Wallet/WalletViewController.swift
+++ b/BraveRewardsUI/Wallet/WalletViewController.swift
@@ -235,7 +235,7 @@ class WalletViewController: UIViewController, RewardsSummaryProtocol {
       guard let self = self, let publisher = self.publisher else { return }
       
       // setting publisher exclusion to .included didn't seem to work, using .default instead.
-      let state: PublisherExclude = enabled ? .default : .excluded
+      let state: PublisherExclude = enabled ? .included : .excluded
       self.state.ledger.updatePublisherExclusionState(withId: publisher.id, state: state)
     }
   }

--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@ A UI framework for consuming Brave Rewards on [brave-ios](https://github.com/bra
 The latest BraveRewards.framework was built on:
 
 ```
-brave-browser/547e52897122c090e886a5bb3340ab89f085a4f3
-brave-core/8abf25420a8d7301f3dd4b251b62cf26cd7e5182
+brave-browser/93d32c2c6ede3c3aa3abbfa3d40436cc5e2b7f2c
+brave-core/ba4925817ddd74f855993e5224c3ff6e01224614
 ```
 
 Building the code

--- a/lib/BraveRewards.framework/Headers/BATBraveAds.h
+++ b/lib/BraveRewards.framework/Headers/BATBraveAds.h
@@ -14,7 +14,7 @@ typedef NS_ENUM(NSInteger, BATAdsNotificationEventType) {
 
 NS_ASSUME_NONNULL_BEGIN
 
-@class BATAdsNotification, BATBraveAds;
+@class BATAdsNotification, BATBraveAds, BATBraveLedger;
 
 NS_SWIFT_NAME(BraveAdsNotificationHandler)
 @protocol BATBraveAdsNotificationHandler
@@ -37,6 +37,8 @@ NS_SWIFT_NAME(BraveAdsNotificationHandler)
 
 NS_SWIFT_NAME(BraveAds)
 @interface BATBraveAds : NSObject
+
+@property (nonatomic, weak) BATBraveLedger *ledger;
 
 /// The notifications handler.
 ///

--- a/lib/BraveRewards.framework/Headers/BATBraveLedger.h
+++ b/lib/BraveRewards.framework/Headers/BATBraveLedger.h
@@ -239,12 +239,18 @@ NS_SWIFT_NAME(BraveLedger)
 
 #pragma mark - Ads & Confirmations
 
+/// Confirm an ad and update confirmations (called from the ads layer)
+- (void)confirmAd:(NSString *)info;
+
+/// Set catalog issuers ad and update confirmations (called from the ads layer)
+- (void)setCatalogIssuers:(NSString *)issuers;
+
 /// Update ad totals on month roll over without fetching latest balances from
 /// server
 - (void)updateAdsRewards;
 
 /// Get the number of ads received and the estimated earnings of viewing said ads for this cycle
-- (void)adsDetailsForCurrentCycle:(void (^)(NSInteger adsReceived, double estimatedEarnings))completion NS_SWIFT_NAME(adsDetailsForCurrentCycle(_:));
+- (void)adsDetailsForCurrentCycle:(void (^)(NSInteger adsReceived, double estimatedEarnings, NSDate * _Nullable nextPaymentDate))completion NS_SWIFT_NAME(adsDetailsForCurrentCycle(_:));
 
 #pragma mark - Notifications
 


### PR DESCRIPTION
- Ads payout date is now provided by native libs
- Now uses correct locale identifier for determining if ads is available
- Use correct `.included` instead of `.default` for updating publisher exclusion state