### PR TITLE
Fixed #188 by setting isExclusiveTouch as false for RewardsUI

### DIFF
--- a/BraveRewardsUI/RewardsPanelController.swift
+++ b/BraveRewardsUI/RewardsPanelController.swift
@@ -11,7 +11,8 @@ public class RewardsPanelController: PopoverNavigationController {
   
   public init(_ rewards: BraveRewards, tabId: UInt64, url: URL, faviconURL: URL?, pageHTML: String? = nil, delegate: RewardsUIDelegate, dataSource: RewardsDataSource) {
     super.init()
-    
+    // Fixes #188. Stop multi touch to avoid race conditions.
+    UIView.appearance().isExclusiveTouch = true
     let state = RewardsState(ledger: rewards.ledger, ads: rewards.ads, tabId: tabId, url: url, faviconURL: faviconURL, delegate: delegate, dataSource: dataSource)
     
     if !rewards.ledger.isWalletCreated {


### PR DESCRIPTION
Issue can be reproduces as below:
 -> Open Brave rewards Panel.
-> Touch any Button (keep touching)
-> Touch another button

Expected:
The second button should not highlight ie receive touch

Actual:
The second button also receives touch event.

Fixed by making the RewardsUI as an ExclusiveTouch UI