### PR TITLE
Ref #229: Always use light theme for Rewards UI on iOS 13.

### DIFF
--- a/BraveRewardsUI/RewardsPanelController.swift
+++ b/BraveRewardsUI/RewardsPanelController.swift
@@ -25,5 +25,8 @@ public class RewardsPanelController: PopoverNavigationController {
     super.viewDidLoad()
     
     navigationBar.tintColor = Colors.blurple400
+    if #available(iOS 13.0, *) {
+      overrideUserInterfaceStyle = .light
+    }
   }
 }


### PR DESCRIPTION
This fix makes all rewards UI on iOS 13 to look good.

fixing iOS 12 will be harder, if not impossible without moving the codebase over to brave-ios